### PR TITLE
Test client

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -4,8 +4,6 @@ import (
 	"github.com/skycoin/skycoin-exchange/src/client"
 )
 
-//forget it, just use blockchain.info api or blockr api
-
 func main() {
 	client.Run()
 }

--- a/examples/example.cdsl
+++ b/examples/example.cdsl
@@ -5,6 +5,7 @@ ListAccounts
 
 WalletPassphrase $WALLET_PASSPHRASE 360
 CreateNewAccount SourceAccount
+GetAccountAddress SourceAccount
 GetBalance SourceAccount
 
 CreateNewAccount TargetAccount

--- a/examples/example.cdsl
+++ b/examples/example.cdsl
@@ -1,0 +1,12 @@
+btwallet.Ping
+btcd.Ping
+ListUnspent
+ListAccounts
+
+WalletPassphrase $WALLET_PASSPHRASE 360
+CreateNewAccount SourceAccount
+GetBalance SourceAccount
+
+CreateNewAccount TargetAccount
+GetAccountAddress TargetAccount
+SendFrom SourceAccount $0 0

--- a/examples/example.cdsl
+++ b/examples/example.cdsl
@@ -1,13 +1,17 @@
-btwallet.Ping
+btcwallet.Ping
 btcd.Ping
-ListUnspent
-ListAccounts
+btcwallet.ListUnspent
+btcwallet.ListAccounts
 
-WalletPassphrase $WALLET_PASSPHRASE 360
-CreateNewAccount SourceAccount
-GetAccountAddress SourceAccount
-GetBalance SourceAccount
+btcwallet.WalletPassphrase $WALLET_PASSPHRASE 360
+btcwallet.CreateNewAccount SourceAccount
+btcwallet.GetAccountAddress SourceAccount
+btcwallet.GetBalance SourceAccount
 
-CreateNewAccount TargetAccount
-GetAccountAddress TargetAccount
-SendFrom SourceAccount $0 0
+btcwallet.CreateNewAccount TargetAccount
+btcwallet.GetAccountAddress TargetAccount
+btcwallet.SendFrom SourceAccount $0 0
+
+skycoin.CreateNewAccount TargetAccount
+skycoin.GetAccountAddress TargetAccount
+skycoin.SendFrom SourceAccount $0

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -4,41 +4,20 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"reflect"
-	"strings"
-	// "github.com/btcsuite/btcd/wire"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcutil"
 	"github.com/deiwin/interact"
-	// "time"
-	//ui "github.com/gizak/termui" // <- ui shortcut, optional
 )
-
-// var (
-// 	checkNotEmpty = func(input string) error {
-// 		// note that the inputs provided to these checks are already trimmed
-// 		if input == "" {
-// 			return errors.New("Input should not be empty!")
-// 		}
-// 		return nil
-// 	}
-// 	checkIsAPositiveNumber = func(input string) error {
-// 		if n, err := strconv.Atoi(input); err != nil {
-// 			return err
-// 		} else if n < 0 {
-// 			return errors.New("The number can not be negative!")
-// 		}
-// 		return nil
-// 	}
-// )
 
 func GetCerts(app string) []byte {
 	homeDir := btcutil.AppDataDir(app, false)
@@ -50,18 +29,7 @@ func GetCerts(app string) []byte {
 }
 
 func BtClient(config *Config, certs []byte, host string) *btcrpcclient.Client {
-	// Only override the handlers for notifications you care about.
-	// Also note most of these handlers will only be called if you register
-	// for notifications.  See the documentation of the btcrpcclient
-	// NotificationHandlers type for more details about each handler.
-	ntfnHandlers := btcrpcclient.NotificationHandlers{
-	// OnBlockConnected: func(hash *wire.ShaHash, height int32, time time.Time) {
-	// 	log.Printf("Block connected: %v (%d) %v", hash, height, time)
-	// },
-	// OnBlockDisconnected: func(hash *wire.ShaHash, height int32, time time.Time) {
-	// 	log.Printf("Block disconnected: %v (%d) %v", hash, height, time)
-	// },
-	}
+	ntfnHandlers := btcrpcclient.NotificationHandlers{}
 	connCfg := &btcrpcclient.ConnConfig{
 		Host:         host,
 		Endpoint:     "ws",

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -3,36 +3,20 @@ package client
 import (
 	"errors"
 	"fmt"
-	"github.com/deiwin/interact"
+	"reflect"
+	// "github.com/btcsuite/btcd/wire"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 
+	"github.com/btcsuite/btcrpcclient"
+	"github.com/btcsuite/btcutil"
+	"github.com/deiwin/interact"
+	// "time"
 	//ui "github.com/gizak/termui" // <- ui shortcut, optional
 )
-
-/*
-	Pseudo terminal
-	Draw squares with characterss
-	Events
-	- up
-	- down
-	- left
-	- right
-	- characters
-	- enter
-
-	notebook
-	commands (Assignment?)
-
-	widgets
-	clicks
-	focus
-	opengl (cross platform)
-
-	actions (need for loop for bootstrapping self containment)
-
-*/
 
 var (
 	checkNotEmpty = func(input string) error {
@@ -52,29 +36,169 @@ var (
 	}
 )
 
-func Run() {
-	log.Printf("Works")
+func GetCerts(app string) []byte {
+	homeDir := btcutil.AppDataDir(app, false)
+	certs, err := ioutil.ReadFile(filepath.Join(homeDir, "rpc.cert"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	return certs
+}
 
+func BtClient(certs []byte, host string) *btcrpcclient.Client {
+	// Only override the handlers for notifications you care about.
+	// Also note most of these handlers will only be called if you register
+	// for notifications.  See the documentation of the btcrpcclient
+	// NotificationHandlers type for more details about each handler.
+	ntfnHandlers := btcrpcclient.NotificationHandlers{
+	// OnBlockConnected: func(hash *wire.ShaHash, height int32, time time.Time) {
+	// 	log.Printf("Block connected: %v (%d) %v", hash, height, time)
+	// },
+	// OnBlockDisconnected: func(hash *wire.ShaHash, height int32, time time.Time) {
+	// 	log.Printf("Block disconnected: %v (%d) %v", hash, height, time)
+	// },
+	}
+	connCfg := &btcrpcclient.ConnConfig{
+		Host:         host,
+		Endpoint:     "ws",
+		User:         "skycoin",
+		Pass:         "skycoin2016",
+		Certificates: certs,
+	}
+	client, err := btcrpcclient.New(connCfg, &ntfnHandlers)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Register for block connect and disconnect notifications.
+	if err := client.NotifyBlocks(); err != nil {
+		log.Fatal(err)
+	}
+	log.Println("NotifyBlocks: Registration Complete")
+
+	// Get the current block count.
+	blockCount, err := client.GetBlockCount()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Block count: %d", blockCount)
+
+	return client
+}
+
+func ConvertToString(r reflect.Value) string {
+	switch r.Kind() {
+	case reflect.Uint64:
+		return fmt.Sprintf("%d", r)
+	default:
+		log.Fatal("Unsupported kind", r.Kind())
+	}
+	log.Fatal("Unsupported kind", r.Kind())
+	return "not reachable"
+}
+
+func Run() {
+	help := `
+	This is the help.
+
+	Deposit
+		Prompts for type of coin
+		Prompts for value
+		Generate and return address for deposit
+	Withdraw
+		Prompts for type of coin
+		Prompts for value
+		Prompts for destination
+
+	`
+	btcd := BtClient(GetCerts("btcd"), "localhost:8334")
+	btwallet := BtClient(GetCerts("btcwallet"), "localhost:8332")
+	current := reflect.ValueOf(btwallet)
 	actor := interact.NewActor(os.Stdin, os.Stdout)
 
-	message := "type help for help"
-	notEmpty, err := actor.Prompt(message, checkNotEmpty)
-	if err != nil {
-		log.Fatal(err)
-	}
+	for {
+		command, err := actor.Prompt("command")
+		if err != nil {
+			log.Fatal(err)
+		}
+		switch command {
+		case "help":
+			fmt.Println(help)
+		case "use":
+			target, err := actor.Prompt("target")
+			if err != nil {
+				log.Fatal(err)
+			}
+			switch target {
+			case "btcd":
+				current = reflect.ValueOf(btcd)
+			case "btwallet":
+				current = reflect.ValueOf(btwallet)
+			}
+		case "ListAccounts":
+			accounts, e := btwallet.ListAccounts()
+			if e != nil {
+				fmt.Println("Error", e)
+				continue
+			}
+			for k, v := range accounts {
+				fmt.Printf("%s = %s\n", k, v.String())
+			}
+		case "CheckBalance":
+		case "Spend":
+		default:
+			//in := []reflect.Value{reflect.ValueOf(nil)}
+			method := current.MethodByName(command)
+			if !method.IsValid() {
+				fmt.Printf("Method %s not found\n", command)
+				continue
+			}
+			method_value := method.Interface()
+			method_type := reflect.TypeOf(method_value)
+			fmt.Println(method_type)
 
-	fmt.Printf("msg= %s\n", notEmpty)
+			in := []reflect.Value{}
 
-	message = "Please enter a positive number"
-	n1, err := actor.PromptAndRetry(message, checkNotEmpty, checkIsAPositiveNumber)
-	if err != nil {
-		log.Fatal(err)
-	}
-	message = "Please enter another positive number"
-	n2, err := actor.PromptOptionalAndRetry(message, "7", checkNotEmpty, checkIsAPositiveNumber)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Thanks! (%s, %s, %s)\n", notEmpty, n1, n2)
+			for i := 0; i < method_type.NumIn(); i++ {
+				param_type := method_type.In(i)
+				param, err := actor.Prompt(fmt.Sprintf("%s", param_type))
+				if err != nil {
+					fmt.Printf("Invalid input %s\n", err)
+					continue
+				}
+				switch param_type.Kind() {
+				case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int:
+					converted, err := strconv.Atoi(param)
+					if err != nil {
+						fmt.Printf("Invalid input %s\n", err)
+						continue
+					}
+					in = append(in, reflect.ValueOf(converted).Convert(param_type))
+				case reflect.Bool:
+					converted, err := strconv.ParseBool(param)
+					if err != nil {
+						fmt.Printf("Invalid input %s\n", err)
+						continue
+					}
+					in = append(in, reflect.ValueOf(converted).Convert(param_type))
+				case reflect.Float32, reflect.Float64:
+					converted, err := strconv.ParseFloat(param, 64)
+					if err != nil {
+						fmt.Printf("Invalid input %s\n", err)
+						continue
+					}
+					in = append(in, reflect.ValueOf(converted).Convert(param_type))
+				default:
+					in = append(in, reflect.ValueOf(param).Convert(param_type))
+				}
 
+			}
+
+			return_values := method.Call(in)
+			for _, r := range return_values {
+				fmt.Printf("%s: ", r.Kind())
+				fmt.Println(r)
+			}
+		}
+	}
 }

--- a/src/skyclient/client.go
+++ b/src/skyclient/client.go
@@ -1,0 +1,32 @@
+package skyclient
+
+import (
+	"github.com/skycoin/skycoin/src/wallet"
+)
+
+type Client struct {
+	Wallets wallet.Wallets
+}
+
+func New() (*Client, error) {
+	client := Client{}
+	var err error
+	client.Wallets, err = wallet.LoadWallets("wallets/")
+	return &client, err
+}
+
+func (self *Client) CreateNewAccount(accountName string) (string, error) {
+	return accountName, nil
+}
+
+func (self *Client) GetAccountAddress(accountName string) (string, error) {
+	return accountName, nil
+}
+
+func (self *Client) SendFrom(accountName string, addressDestination string) (string, error) {
+	return accountName, nil
+}
+
+func (self *Client) GetBalance(accountName string) (int, error) {
+	return 0, nil
+}


### PR DESCRIPTION
I'm able to:
- create wallet from command-line
- create source and target account using WS RPC
- get target account address
- attempt an empty transfer from source to target address
- using reflection, call any RPC server interface method for which conversion from parameters datatypes is implemented (such as btcutil.address)

TODO
- [ ] switch to simulated/testnet to test with simulated btc moving back and forth
- [ ] implement similar approach for skycoin
- [ ] implement bid/ask commands

Maybe
- [ ] reversible transactions
- [ ] switch to fully asynchronous calls (how to gate outputs for workflow management?)
